### PR TITLE
add example config files

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -132,7 +132,7 @@ Below are steps with screenshots to create and register Launchpad as a Microsoft
      > **Note**:
      > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default. In this case provide the value of `BASE_URL` as `JWT_ISSUER` in the above yaml.
      > 
-     > Here is an example config file:
+     > Suppose the BASE_URL was set to http://localhost:8080, and `JWT_ISSUER` was not set. The jwt.yaml for the Stardog server would look  like:
      > ```yaml
      > issuers:
      >   http://localhost:8080:

--- a/azure/README.md
+++ b/azure/README.md
@@ -131,6 +131,20 @@ Below are steps with screenshots to create and register Launchpad as a Microsoft
 
      > **Note**:
      > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default. In this case provide the value of `BASE_URL` as `JWT_ISSUER` in the above yaml.
+     > 
+     > Here is an example config file:
+     > ```yaml
+     > issuers:
+     >   http://localhost:8080:
+     >     usernameField: username
+     >     audience: http://localhost:5820 
+     >     algorithms:
+     >       RS256:
+     >         keyUrl: http://localhost:8080/.well-known/jwks.json
+     >     autoCreateUsers: True
+     >     allowedGroupIdentifiers:
+     >       - azure.microsoft.com/aa12bb22-ccdd-3fff-4ggg-55h6666iii77
+     > ```
 
 ## Run the Example
 

--- a/google/README.md
+++ b/google/README.md
@@ -101,7 +101,7 @@ issuers:
   > **Note**:
   > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default.
   > 
-  > Here is an example config file:
+  > Suppose the BASE_URL was set to http://localhost:8080, and `JWT_ISSUER` was not set. The jwt.yaml for the Stardog server would look  like:
   > ```yaml
   > issuers:
   >   http://localhost:8080:

--- a/google/README.md
+++ b/google/README.md
@@ -100,6 +100,17 @@ issuers:
 
   > **Note**:
   > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default.
+  > 
+  > Here is an example config file:
+  > ```yaml
+  > issuers:
+  >   http://localhost:8080:
+  >     usernameField: email
+  >     audience: http://localhost:5820 
+  >     algorithms:
+  >       RS256:
+  >         keyUrl: http://localhost:8080/.well-known/jwks.json
+  > ```
 
 ## Run the Example
 

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -139,7 +139,7 @@ issuers:
   > **Note**:
   > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default.
   > 
-  > Here is an example config file:
+  > Suppose the BASE_URL was set to http://localhost:8080, and `JWT_ISSUER` was not set. The jwt.yaml for the Stardog server would look  like:
   > ```yaml
   > issuers:
   >   http://localhost:8080:

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -138,6 +138,20 @@ issuers:
 
   > **Note**:
   > `JWT_ISSUER` by default is set to the value of `BASE_URL`. There is no need to provide the `JWT_ISSUER` environment variable if you are fine using the default.
+  > 
+  > Here is an example config file:
+  > ```yaml
+  > issuers:
+  >   http://localhost:8080:
+  >     usernameField: username
+  >     audience: http://localhost:5820 
+  >     algorithms:
+  >       RS256:
+  >         keyUrl: http://localhost:8080/.well-known/jwks.json
+  >     autoCreateUsers: True
+  >     allowedGroupIdentifiers:
+  >       - keycloakRoles
+  > ```
 
 ## Run the Example
 


### PR DESCRIPTION
To prevent confusion like that experienced by HKJC, I added example config files so that users would know to include ports in their `JWT_ISSUER`.

Didn't include an example for basic because there's no yaml file in that readme in the first place.