### PR TITLE
[CLOUD-1446] added release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains documentation and example configurations for Stardog Launchpad.
 
+Here are the [release notes](./release-notes.md).
+
 ## Overview
 
 Launchpad is a login service for a **single** Stardog instance for access to Stardog Applications (Studio, Explorer, Designer). With the right configurations for Launchpad and

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker login stardog-stardog-apps.jfrog.io
 2. Pull the latest image:
 
 ```
-docker pull stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+docker pull stardog-stardog-apps.jfrog.io/launchpad:current
 ```
 
 3. Configure the Stardog server as needed and create a configuration for Launchpad.
@@ -73,7 +73,7 @@ docker pull stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
      -p 8080:8080 \
      --rm \
      --name stardog-launchpad \
-     stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+     stardog-stardog-apps.jfrog.io/launchpad:current
    ```
 
    - Launchpad will always be served at port `8080` from the container. Map this port as needed.
@@ -111,7 +111,7 @@ docker run \
   -v /host-machine/certs:/certs \
   --rm \
   --name stardog-launchpad \
-  stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+  stardog-stardog-apps.jfrog.io/launchpad:current
 ```
 
 - In the above example, a directory on the host machine `/host-machine/certs` is mounted to the `/certs` directory inside the Docker container. Suppose a CA bundle was contained in the host directory and named `ca-chain.cert.pem`. Then, `STARDOG_SERVER_CERT_PATH` should be set to `/certs/ca-chain.cert.pem`.

--- a/azure/docker-compose.yml
+++ b/azure/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
 
   launchpad:
-    image: stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current 
+    image: stardog-stardog-apps.jfrog.io/launchpad:current
     restart: always
     ports:
       - 8080:8080

--- a/basic/docker-compose.yml
+++ b/basic/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
 
   launchpad:
-    image: stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+    image: stardog-stardog-apps.jfrog.io/launchpad:current
     restart: always
     ports:
       - 8080:8080

--- a/google/docker-compose.yml
+++ b/google/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
 
   launchpad:
-    image: stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+    image: stardog-stardog-apps.jfrog.io/launchpad:current
     restart: always
     ports:
       - 8080:8080

--- a/keycloak/docker-compose.yml
+++ b/keycloak/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 services:
 
   launchpad:
-    image: stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+    image: stardog-stardog-apps.jfrog.io/launchpad:current
     restart: always
     ports:
       - 8080:8080

--- a/release-notes.md
+++ b/release-notes.md
@@ -15,18 +15,18 @@ docker login stardog-stardog-apps.jfrog.io
 2. Pull the latest image:
 
 ```bash
-docker pull stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+docker pull stardog-stardog-apps.jfrog.io/launchpad:current
 ```
 
 ## Version Scheme
 
-Stardog Launchpad container releases are versioned as `vX.Y.Z` where:
+Stardog Launchpad releases are versioned as `vX.Y.Z` where:
 
    - `X` represents the (minimum) version of the Stardog platform required to use all current Launchpad features; this value will increment when the minimum required version of Stardog changes
    - `Y` represents the current version of Launchpad features; this value will increment when new features or bug fixes are added to the Launchpad login web app
    - `Z` represents the versions of the Stardog Applications included in the Docker container (see the table below); this value will increment when one or more of the Stardog Applications are updated
 
-# Launchpad Container Releases
+# Launchpad Releases
 
 | Release | Stardog Version | Designer Version | Explorer Version | Studio Version |
 | ------- | --------------- | ---------------- | ---------------- | -------------- |

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 # Launchpad Release Notes
 
-Stardog Launchpad is distributed as a Docker container, which includes the Launchpad login web app together with the Stardog Applications (Studio, Explorer, and Designer). The Stardog Platform server is not included in the Launchpad Docker container.
+Stardog Launchpad is distributed as a Docker image, which includes the Launchpad login web app together with the Stardog Applications (Studio, Explorer, and Designer). The Stardog Platform server is not included in the Launchpad Docker image.
 
 ## Getting the Current Version of Launchpad
 
@@ -24,7 +24,7 @@ Stardog Launchpad releases are versioned as `vX.Y.Z` where:
 
    - `X` represents the (minimum) version of the Stardog platform required to use all current Launchpad features; this value will increment when the minimum required version of Stardog changes
    - `Y` represents the current version of Launchpad features; this value will increment when new features or bug fixes are added to the Launchpad login web app
-   - `Z` represents the versions of the Stardog Applications included in the Docker container (see the table below); this value will increment when one or more of the Stardog Applications are updated
+   - `Z` represents the versions of the Stardog Applications included in the Docker image (see the table below); this value will increment when one or more of the Stardog Applications are updated
 
 # Launchpad Releases
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,43 @@
+# Launchpad Release Notes
+
+Stardog Launchpad is distributed as a Docker container, which includes the Launchpad login web app together with the Stardog Applications (Studio, Explorer, and Designer). The Stardog Platform server is not included in the Launchpad Docker container.
+
+## Getting the Current Version of Launchpad
+
+The latest release of Launchpad is available from Stardog's Docker registry:
+
+1. Log in to the Docker registry:
+
+```bash
+docker login stardog-stardog-apps.jfrog.io
+```
+
+2. Pull the latest image:
+
+```bash
+docker pull stardog-stardog-apps.jfrog.io/cloud-login:launchpad-current
+```
+
+## Version Scheme
+
+Stardog Launchpad container releases are versioned as `vX.Y.Z` where:
+
+   - `X` represents the (minimum) version of the Stardog platform required to use all current Launchpad features; this value will increment when the minimum required version of Stardog changes
+   - `Y` represents the current version of Launchpad features; this value will increment when new features or bug fixes are added to the Launchpad login web app
+   - `Z` represents the versions of the Stardog Applications included in the Docker container (see the table below); this value will increment when one or more of the Stardog Applications are updated
+
+# Launchpad Container Releases
+
+| Release | Stardog Version | Designer Version | Explorer Version | Studio Version |
+| ------- | --------------- | ---------------- | ---------------- | -------------- |
+| 2.0.0   | [9.1.0](https://docs.stardog.com/release-notes/stardog-platform#910-release-2023-07-06) | [2.24.0](https://docs.stardog.com/release-notes/stardog-designer#v2240-release) | [1.26.3](https://docs.stardog.com/release-notes/stardog-explorer#v1263-release) | [4.1.1](https://docs.stardog.com/release-notes/stardog-studio#v411-release) |
+
+## 2.0.0 Release (2023-09-27)
+
+### Launchpad Updates
+- Support using a client certificate when authenticating to Azure (#CLOUD-1332); see [config doc](./azure/client-certificate-config.md)
+- Support access token passthrough mode with Azure (#CLOUD-1278); see [config doc](./azure/access-token-passthrough-mode.md)
+- Disable Django Admin (#CLOUD-1489)
+
+### Stardog Notes
+- Stardog Platform version 9.1.0 (or later) is required to use the access token passthrough feature. Other Launchpad features require at least version 9.0.0 of Stardog.


### PR DESCRIPTION
These are the release notes for the first official release of Launchpad. The versioning scheme is a bit "different", but mainly it boils down to wanting to indicates its dependencies on both the Stardog platform and the VET apps (in addition to its own features and bug fixes).

The next step is for me to build the v2.0.0 release of Launchpad and kick the tires. Once it looks good, I will merge this PR and Launchpad will be, well, launched.