### PR TITLE
Add v3.11.0 release notes and Voicebox beta deployment guide

### DIFF
--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -1,11 +1,14 @@
-# Deploying the Voicebox Service for the Beta
+# Deploying the Voicebox Service (Public API Beta)
+
+> [!IMPORTANT]
+> **Applies to:** Launchpad v3.11.0+ · Voicebox Service `v1.0.0-beta.1` (beta)
+>
+> Routing public API traffic to the beta service requires **Launchpad v3.11.0 or later** - earlier versions have no `VOICEBOX_BETA_SERVICE_ENDPOINT` routing, so the beta service receives no traffic.
 
 A practical guide for deploying the Voicebox Service that powers the Launchpad beta: what the frame store is, what changes versus a stateless service, what you need to set, and what logs to watch.
 
 > [!NOTE]
 > The beta runs on a dedicated **beta** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
->
-> Routing public API traffic to the beta service requires **Launchpad v3.11.0 or later** — earlier versions have no `VOICEBOX_BETA_SERVICE_ENDPOINT` routing, so the beta service receives no traffic.
 
 ## Background
 
@@ -49,7 +52,7 @@ flowchart TD
     C -->|Yes| BE[Beta service<br/>VOICEBOX_BETA_SERVICE_ENDPOINT]
 ```
 
-This is not a new public API. The endpoints and response format are unchanged — the beta only swaps the backend service that handles these existing public API requests, so no client changes are needed.
+This is not a new public API. The endpoints and response format are unchanged - the beta only swaps the backend service that handles these existing public API requests, so no client changes are needed.
 
 The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set `VOICEBOX_BETA_SERVICE_ENDPOINT`, the beta service receives no traffic.
 
@@ -64,6 +67,9 @@ The rest of this guide covers the **beta service**, which carries the storage re
 - **A readiness endpoint exists.** `GET /system/storage-ready` reports whether the frame path is actually writable, so a bad mount surfaces at startup rather than at first query.
 
 ## Configuration
+
+> [!NOTE]
+> This section covers **only** the storage settings the beta adds. Everything else about running the Voicebox Service is unchanged: the `vbx-config.json` configuration file, the supported LLM providers (Azure AI, AWS Bedrock, OpenAI, Anthropic, Databricks, Vertex AI, Fireworks), and the standard environment variables all still apply. See [Voicebox Service Configuration](../voicebox.md#configuration) and the [Voicebox Configuration File](../voicebox.md#voicebox-configuration-file) reference.
 
 ### Required: mount a volume
 

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -1,0 +1,88 @@
+# Deploying the Voicebox Service for the Beta
+
+A practical guide for deploying the Voicebox Service that powers the Launchpad beta: what the frame store is, what changes versus a stateless service, what you need to set, and what logs to watch.
+
+> [!NOTE]
+> The beta runs on an **experimental** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
+
+## Background
+
+The experimental Voicebox Service produces **frames**: the tabular results behind a conversation turn. It persists them so a later turn can reuse a previous result without re-querying Stardog. Frames are written as snappy-compressed Parquet files on local disk, one file per frame, laid out as `{frame_store_path}/{context_id}/{frame_id}.parquet`.
+
+Conversation memory is separate from frames. Launchpad resends the conversation lineage on every turn, so the server holds no per-conversation memory between turns. The practical upshot is that **frames are an optimization, not a source of truth**. If a frame is missing (disk full, volume lost, expired), the service recomputes it from Stardog. Nothing is corrupted; you pay recompute time.
+
+### Beta Deployment Shape
+
+The beta runs **two Voicebox Service deployments side by side from the same image at different tags**:
+
+- **stable** (the `0.x` line, currently `v0.29.0`): the existing service serving today's Voicebox endpoints. Runs as one or more instances and keeps no local frame store.
+- **experimental** (`v1.0.0-beta.1`): the new service. It persists result frames to local disk, so it runs as a **single instance**, and for the beta serves public API requests only.
+
+Launchpad routes per request: a public API request goes to the experimental service when a feature flag is enabled (and `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT` is set); everything else goes to the stable service (`VOICEBOX_SERVICE_ENDPOINT`). Both are internal only.
+
+| | stable (`v0.29.0`) | experimental (`v1.0.0-beta.1`) |
+| :--- | :--- | :--- |
+| Instances | one or more | exactly 1 (local-disk store) |
+| Persisted results | none (recomputed from Stardog) | local frame store on a volume |
+| Traffic | default Voicebox traffic | public API requests (flag-gated) |
+
+The rest of this guide covers the **experimental service**, which carries the storage requirements.
+
+## What Changes Versus a Stateless Deployment
+
+- **A persistent volume is now required.** Frames must outlive container restarts, so mount a volume at the frame store path. Without it, frames land in the container's writable layer and vanish on restart (the service still works, it just re-fetches from Stardog).
+- **It runs as a single instance.** Its store is the pod's own disk; a second replica would read an empty store. The stable service scales normally.
+- **Eviction is built in.** A background sweeper deletes frames older than a TTL (7 days by default) and reaps orphaned `.tmp` files after 1 hour. No external cron or cleanup job is needed.
+- **Disk-full is non-fatal.** When the volume fills, the user still gets their answer; the frame just isn't written and a `local_disk.disk_full` warning is logged. Recover by growing the volume or lowering the TTL.
+- **A readiness endpoint exists.** `GET /system/storage-ready` reports whether the frame path is actually writable, so a bad mount surfaces at startup rather than at first query.
+
+## Configuration
+
+### Required
+
+Set the backend explicitly so intent is visible in config:
+
+| Environment Variable | Value | Why |
+| :--- | :--- | :--- |
+| `VOICEBOX_FRAME_STORE_BACKEND` | `local` | The default; set explicitly so the storage mode is obvious in your config. |
+
+Then mount a writable volume at the frame store path (default `/var/lib/voicebox/v4/frames`):
+
+- **Docker (named volume):** Mount it at the frame store path. The image pre-creates that directory owned by the non-root container user, and a named volume inherits that ownership, so no extra steps are needed. Prefer a named volume over a bind mount.
+- **Kubernetes:** Use a single-replica deployment with a `ReadWriteOnce` persistent volume mounted at the frame store path, a `Recreate` update strategy, and a security context that makes the mount writable by the non-root container user.
+
+### Commonly Tuned Settings
+
+Most deployments only touch these. Leave the rest at their defaults.
+
+| Environment Variable | Default | When to change |
+| :--- | :--- | :--- |
+| `VOICEBOX_FRAME_STORE_LOCAL_PATH` | `/var/lib/voicebox/v4/frames` | Only if you mount the volume somewhere else. |
+| `VOICEBOX_FRAME_STORE_LOCAL_TTL_DAYS` | `7` | Lower on a small volume to reclaim disk faster; raise for longer-lived conversations. Must be `> 0` while the sweeper is enabled. |
+| `VOICEBOX_FRAME_STORE_SWEEPER_ENABLED` | `true` | Set to `false` to disable the background eviction sweeper entirely. |
+| `VOICEBOX_FRAME_STORE_LARGE_FRAME_WARN_MB` | `10` | Lower for earlier oversized-frame warnings; `0` disables them. |
+
+> [!TIP]
+> **Sizing.** Rough disk need is `avg frame size × frames per turn × turns per day × TTL days`. 20 GB is a comfortable start for a small team at the 7-day default. Use the `frame_store.capacity` log (below) to trend real usage and resize from data.
+
+## Health and Readiness Probes
+
+- **Liveness:** `GET /system/health` (returns `204`).
+- **Readiness:** `GET /system/storage-ready` (`200` when the frame path is writable, `503` otherwise).
+
+Keep the disk-writability check on **readiness**, not liveness, so a transient full disk pulls the instance from traffic instead of restarting it into a crash loop.
+
+## Log Events
+
+Logs are emitted as structured JSON when `LOG_TYPE=JSON` (the default): each line is a JSON object keyed by an `event` field, so you can alert on the event name.
+
+| Event | Level | Meaning / action |
+| :--- | :--- | :--- |
+| `local_disk.disk_full` | `WARNING` | A write ran out of disk space. Users still get answers; frames aren't persisting. Carries `disk_free_bytes` / `disk_total_bytes`. **Alert.** Grow the volume or shorten the TTL. |
+| `frame_store.capacity` | `INFO` | Periodic volume telemetry: `disk_free_bytes`, `disk_total_bytes`, `file_count`. Alert proactively when free space drops below a threshold (for example 15 percent). |
+| `frame_store.readiness` | `WARNING` (`ready=false`) / `INFO` (`ready=true`) | Frame path writability changed. `ready=false` means a missing or unwritable mount. **Alert on `ready=false`.** Carries `path`, `detail`. |
+| `local_disk.large_frame` | `WARNING` | A single frame exceeded the warn threshold. Carries `size_bytes` / `threshold_bytes`. Informational; a spike can signal runaway result sizes. |
+| `frame_store_sweep.cycle` | `INFO` | A sweep pass finished: `scanned`, `deleted`, `skipped_recent`, `tmp_deleted`, `errors`, `elapsed_ms`. Watch `errors` and `elapsed_ms`. |
+| `voicebox_v4_backends` | `INFO` | Startup banner: resolved backends, frame path, and `frame_local_writable`. Use it to confirm your config and mount took effect. |
+
+The readiness monitor logs only on a **change**, so a healthy service stays quiet; a single `ready=false` is the signal that something changed.

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -8,7 +8,7 @@
 A practical guide for deploying the Voicebox Service that powers the Launchpad beta: what the frame store is, what changes versus a stateless service, what you need to set, and what logs to watch.
 
 > [!NOTE]
-> The beta runs on a dedicated **beta** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
+> The beta runs on a dedicated **beta** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is not exposed publicly; clients reach it only through Launchpad's public API, which forwards requests to the service over the internal network. It is intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.30.0`) is unaffected by everything in this guide.
 
 ## Background
 
@@ -20,20 +20,20 @@ Conversation memory is separate from frames. Launchpad resends the conversation 
 
 The beta runs **two Voicebox Service deployments side by side from the same image at different tags**:
 
-- **stable** (the `0.x` line, currently `v0.29.0`): the existing service serving today's Voicebox endpoints. Runs as one or more instances and keeps no local frame store.
+- **stable** (the `0.x` line, currently `v0.30.0`): the existing service serving today's Voicebox endpoints. Runs as one or more instances and keeps no local frame store.
 - **beta** (`v1.0.0-beta.1`): the new service. It persists result frames to local disk, so it runs as a **single instance**, and for the beta serves public API requests only.
 
-Both are internal only. Launchpad talks to each through its own endpoint:
+Neither service is exposed publicly; Launchpad reaches each one over the internal network through its own endpoint:
 
 ```mermaid
 flowchart LR
     LP([Launchpad])
-    LP -->|VOICEBOX_SERVICE_ENDPOINT| ST["Stable service<br/>v0.29.0 · stateless<br/>one or more instances"]
+    LP -->|VOICEBOX_SERVICE_ENDPOINT| ST["Stable service<br/>v0.30.0 · stateless<br/>one or more instances"]
     LP -->|VOICEBOX_BETA_SERVICE_ENDPOINT| BE["Beta service<br/>v1.0.0-beta.1 · single instance"]
     BE --> FS[("Local frame store<br/>persistent volume")]
 ```
 
-| | stable (`v0.29.0`) | beta (`v1.0.0-beta.1`) |
+| | stable (`v0.30.0`) | beta (`v1.0.0-beta.1`) |
 | :--- | :--- | :--- |
 | Instances | one or more | exactly 1 (local-disk store) |
 | Persisted results | none (recomputed from Stardog) | local frame store on a volume |
@@ -52,7 +52,22 @@ flowchart TD
     C -->|Yes| BE[Beta service<br/>VOICEBOX_BETA_SERVICE_ENDPOINT]
 ```
 
+A typical configuration sets both endpoints explicitly:
+
+```bash
+VOICEBOX_SERVICE_ENDPOINT=http://voicebox-stable:8000
+VOICEBOX_BETA_SERVICE_ENDPOINT=http://voicebox-beta:8000
+```
+
 This is not a new public API. The endpoints and response format are unchanged - the beta only swaps the backend service that handles these existing public API requests, so no client changes are needed.
+
+Only these public API endpoints route to the beta service:
+
+- `POST /api/v1/voicebox/ask`
+- `POST /api/v1/voicebox/generate-query`
+- `POST /api/v1/voicebox/stream/ask`
+
+All other Voicebox traffic - including the BITES public APIs - continues to the stable service.
 
 The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set `VOICEBOX_BETA_SERVICE_ENDPOINT`, the beta service receives no traffic.
 
@@ -109,9 +124,6 @@ Logs are emitted as structured JSON when `LOG_TYPE=JSON` (the default): each lin
 | :--- | :--- | :--- |
 | `local_disk.disk_full` | `WARNING` | A write ran out of disk space. Users still get answers; frames aren't persisting. Carries `disk_free_bytes` / `disk_total_bytes`. **Alert.** Grow the volume or shorten the TTL. |
 | `frame_store.capacity` | `INFO` | Periodic volume telemetry: `disk_free_bytes`, `disk_total_bytes`, `file_count`. Alert proactively when free space drops below a threshold (for example 15 percent). |
-| `frame_store.readiness` | `WARNING` (`ready=false`) / `INFO` (`ready=true`) | Frame path writability changed. `ready=false` means a missing or unwritable mount. **Alert on `ready=false`.** Carries `path`, `detail`. |
 | `local_disk.large_frame` | `WARNING` | A single frame exceeded the warn threshold. Carries `size_bytes` / `threshold_bytes`. Informational; a spike can signal runaway result sizes. |
 | `frame_store_sweep.cycle` | `INFO` | A sweep pass finished: `scanned`, `deleted`, `skipped_recent`, `tmp_deleted`, `errors`, `elapsed_ms`. Watch `errors` and `elapsed_ms`. |
 | `voicebox_backends` | `INFO` | Startup banner: resolved backends, frame path, and `frame_local_writable`. Use it to confirm your config and mount took effect. |
-
-The readiness monitor logs only on a **change**, so a healthy service stays quiet; a single `ready=false` is the signal that something changed.

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -4,6 +4,8 @@ A practical guide for deploying the Voicebox Service that powers the Launchpad b
 
 > [!NOTE]
 > The beta runs on a dedicated **beta** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
+>
+> Routing public API traffic to the beta service requires **Launchpad v3.11.0 or later** — earlier versions have no `VOICEBOX_BETA_SERVICE_ENDPOINT` routing, so the beta service receives no traffic.
 
 ## Background
 

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -47,6 +47,8 @@ flowchart TD
     C -->|Yes| BE[Beta service<br/>VOICEBOX_BETA_SERVICE_ENDPOINT]
 ```
 
+This is not a new public API. The endpoints and response format are unchanged — the beta only swaps the backend service that handles these existing public API requests, so no client changes are needed.
+
 The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set `VOICEBOX_BETA_SERVICE_ENDPOINT`, the beta service receives no traffic.
 
 The rest of this guide covers the **beta service**, which carries the storage requirements.

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -3,11 +3,11 @@
 A practical guide for deploying the Voicebox Service that powers the Launchpad beta: what the frame store is, what changes versus a stateless service, what you need to set, and what logs to watch.
 
 > [!NOTE]
-> The beta runs on an **experimental** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
+> The beta runs on a dedicated **beta** build of the Voicebox Service, tagged `v1.0.0-beta.1`. It is internal only and intended to be temporary while the beta is in progress. The **stable** service (the `0.x` line, currently `v0.29.0`) is unaffected by everything in this guide.
 
 ## Background
 
-The experimental Voicebox Service produces **frames**: the tabular results behind a conversation turn. It persists them so a later turn can reuse a previous result without re-querying Stardog. Frames are written as snappy-compressed Parquet files on local disk, one file per frame, laid out as `{frame_store_path}/{context_id}/{frame_id}.parquet`.
+The beta Voicebox Service produces **frames**: the tabular results of the queries it runs against Stardog to answer a conversation turn. It persists them so a later turn can reuse a previous result without re-querying Stardog. Frames are written as snappy-compressed Parquet files on local disk, one file per frame, laid out as `{frame_store_path}/{conversation_id}/{frame_id}.parquet`.
 
 Conversation memory is separate from frames. Launchpad resends the conversation lineage on every turn, so the server holds no per-conversation memory between turns. The practical upshot is that **frames are an optimization, not a source of truth**. If a frame is missing (disk full, volume lost, expired), the service recomputes it from Stardog. Nothing is corrupted; you pay recompute time.
 
@@ -16,17 +16,40 @@ Conversation memory is separate from frames. Launchpad resends the conversation 
 The beta runs **two Voicebox Service deployments side by side from the same image at different tags**:
 
 - **stable** (the `0.x` line, currently `v0.29.0`): the existing service serving today's Voicebox endpoints. Runs as one or more instances and keeps no local frame store.
-- **experimental** (`v1.0.0-beta.1`): the new service. It persists result frames to local disk, so it runs as a **single instance**, and for the beta serves public API requests only.
+- **beta** (`v1.0.0-beta.1`): the new service. It persists result frames to local disk, so it runs as a **single instance**, and for the beta serves public API requests only.
 
-Launchpad routes per request: a public API request goes to the experimental service when a feature flag is enabled (and `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT` is set); everything else goes to the stable service (`VOICEBOX_SERVICE_ENDPOINT`). Both are internal only.
+Both are internal only. Launchpad talks to each through its own endpoint:
 
-| | stable (`v0.29.0`) | experimental (`v1.0.0-beta.1`) |
+```mermaid
+flowchart LR
+    LP([Launchpad])
+    LP -->|VOICEBOX_SERVICE_ENDPOINT| ST["Stable service<br/>v0.29.0 · stateless<br/>one or more instances"]
+    LP -->|VOICEBOX_BETA_SERVICE_ENDPOINT| BE["Beta service<br/>v1.0.0-beta.1 · single instance"]
+    BE --> FS[("Local frame store<br/>persistent volume")]
+```
+
+| | stable (`v0.29.0`) | beta (`v1.0.0-beta.1`) |
 | :--- | :--- | :--- |
 | Instances | one or more | exactly 1 (local-disk store) |
 | Persisted results | none (recomputed from Stardog) | local frame store on a volume |
 | Traffic | default Voicebox traffic | public API requests (flag-gated) |
 
-The rest of this guide covers the **experimental service**, which carries the storage requirements.
+### How Traffic Is Routed
+
+Launchpad routes **per request**. A request only reaches the beta service when it is a public API request *and* the beta is fully configured — the feature flag is enabled and `VOICEBOX_BETA_SERVICE_ENDPOINT` is set. Everything else falls back to the stable service, so a half-configured or unconfigured beta simply means all traffic keeps flowing to stable:
+
+```mermaid
+flowchart TD
+    R([Request reaches Launchpad]) --> Q{Public API request?}
+    Q -->|No| ST[Stable service<br/>VOICEBOX_SERVICE_ENDPOINT]
+    Q -->|Yes| C{Beta flag enabled<br/>AND VOICEBOX_BETA_SERVICE_ENDPOINT set?}
+    C -->|No| ST
+    C -->|Yes| BE[Beta service<br/>VOICEBOX_BETA_SERVICE_ENDPOINT]
+```
+
+The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set both the flag and the endpoint, the beta service receives no traffic.
+
+The rest of this guide covers the **beta service**, which carries the storage requirements.
 
 ## What Changes Versus a Stateless Deployment
 
@@ -38,15 +61,9 @@ The rest of this guide covers the **experimental service**, which carries the st
 
 ## Configuration
 
-### Required
+### Required: mount a volume
 
-Set the backend explicitly so intent is visible in config:
-
-| Environment Variable | Value | Why |
-| :--- | :--- | :--- |
-| `VOICEBOX_FRAME_STORE_BACKEND` | `local` | The default; set explicitly so the storage mode is obvious in your config. |
-
-Then mount a writable volume at the frame store path (default `/var/lib/voicebox/v4/frames`):
+Mount a writable volume at the frame store path (default `/var/lib/voicebox/frames`):
 
 - **Docker (named volume):** Mount it at the frame store path. The image pre-creates that directory owned by the non-root container user, and a named volume inherits that ownership, so no extra steps are needed. Prefer a named volume over a bind mount.
 - **Kubernetes:** Use a single-replica deployment with a `ReadWriteOnce` persistent volume mounted at the frame store path, a `Recreate` update strategy, and a security context that makes the mount writable by the non-root container user.
@@ -57,7 +74,6 @@ Most deployments only touch these. Leave the rest at their defaults.
 
 | Environment Variable | Default | When to change |
 | :--- | :--- | :--- |
-| `VOICEBOX_FRAME_STORE_LOCAL_PATH` | `/var/lib/voicebox/v4/frames` | Only if you mount the volume somewhere else. |
 | `VOICEBOX_FRAME_STORE_LOCAL_TTL_DAYS` | `7` | Lower on a small volume to reclaim disk faster; raise for longer-lived conversations. Must be `> 0` while the sweeper is enabled. |
 | `VOICEBOX_FRAME_STORE_SWEEPER_ENABLED` | `true` | Set to `false` to disable the background eviction sweeper entirely. |
 | `VOICEBOX_FRAME_STORE_LARGE_FRAME_WARN_MB` | `10` | Lower for earlier oversized-frame warnings; `0` disables them. |
@@ -83,6 +99,6 @@ Logs are emitted as structured JSON when `LOG_TYPE=JSON` (the default): each lin
 | `frame_store.readiness` | `WARNING` (`ready=false`) / `INFO` (`ready=true`) | Frame path writability changed. `ready=false` means a missing or unwritable mount. **Alert on `ready=false`.** Carries `path`, `detail`. |
 | `local_disk.large_frame` | `WARNING` | A single frame exceeded the warn threshold. Carries `size_bytes` / `threshold_bytes`. Informational; a spike can signal runaway result sizes. |
 | `frame_store_sweep.cycle` | `INFO` | A sweep pass finished: `scanned`, `deleted`, `skipped_recent`, `tmp_deleted`, `errors`, `elapsed_ms`. Watch `errors` and `elapsed_ms`. |
-| `voicebox_v4_backends` | `INFO` | Startup banner: resolved backends, frame path, and `frame_local_writable`. Use it to confirm your config and mount took effect. |
+| `voicebox_backends` | `INFO` | Startup banner: resolved backends, frame path, and `frame_local_writable`. Use it to confirm your config and mount took effect. |
 
 The readiness monitor logs only on a **change**, so a healthy service stays quiet; a single `ready=false` is the signal that something changed.

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -32,22 +32,22 @@ flowchart LR
 | :--- | :--- | :--- |
 | Instances | one or more | exactly 1 (local-disk store) |
 | Persisted results | none (recomputed from Stardog) | local frame store on a volume |
-| Traffic | default Voicebox traffic | public API requests (flag-gated) |
+| Traffic | default Voicebox traffic | public API requests (when endpoint is set) |
 
 ### How Traffic Is Routed
 
-Launchpad routes **per request**. A request only reaches the beta service when it is a public API request *and* the beta is fully configured — the feature flag is enabled and `VOICEBOX_BETA_SERVICE_ENDPOINT` is set. Everything else falls back to the stable service, so a half-configured or unconfigured beta simply means all traffic keeps flowing to stable:
+Launchpad routes **per request**. A request only reaches the beta service when it is a public API request *and* `VOICEBOX_BETA_SERVICE_ENDPOINT` is set. Everything else falls back to the stable service, so leaving the endpoint unset simply means all traffic keeps flowing to stable:
 
 ```mermaid
 flowchart TD
     R([Request reaches Launchpad]) --> Q{Public API request?}
     Q -->|No| ST[Stable service<br/>VOICEBOX_SERVICE_ENDPOINT]
-    Q -->|Yes| C{Beta flag enabled<br/>AND VOICEBOX_BETA_SERVICE_ENDPOINT set?}
+    Q -->|Yes| C{VOICEBOX_BETA_SERVICE_ENDPOINT set?}
     C -->|No| ST
     C -->|Yes| BE[Beta service<br/>VOICEBOX_BETA_SERVICE_ENDPOINT]
 ```
 
-The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set both the flag and the endpoint, the beta service receives no traffic.
+The practical upshot: the beta is opt-in and safe to leave unconfigured. Until you set `VOICEBOX_BETA_SERVICE_ENDPOINT`, the beta service receives no traffic.
 
 The rest of this guide covers the **beta service**, which carries the storage requirements.
 

--- a/guides/voicebox-beta-deployment.md
+++ b/guides/voicebox-beta-deployment.md
@@ -78,6 +78,9 @@ Mount a writable volume at the frame store path (default `/var/lib/voicebox/fram
 - **Docker (named volume):** Mount it at the frame store path. The image pre-creates that directory owned by the non-root container user, and a named volume inherits that ownership, so no extra steps are needed. Prefer a named volume over a bind mount.
 - **Kubernetes:** Use a single-replica deployment with a `ReadWriteOnce` persistent volume mounted at the frame store path, a `Recreate` update strategy, and a security context that makes the mount writable by the non-root container user.
 
+> [!NOTE]
+> The local volume is a temporary requirement for the beta. Support for persisting frames to object (blob) storage is in development; once available it will remove the need for a mounted volume and allow the service to scale across multiple replicas.
+
 ### Commonly Tuned Settings
 
 Most deployments only touch these. Leave the rest at their defaults.

--- a/release-notes.md
+++ b/release-notes.md
@@ -34,6 +34,7 @@ Launchpad v3 uses semantic versioning.
 
 | Release | Image Tag | Designer Version | Explorer Version | Studio Version | Knowledge Catalog Version |
 | ----- | ----------- | ------------- | -------------- | -------------- | ------------ |
+| [3.11.0](#3110-release-2026-06-30) | `v3.11.0` | [3.9.7](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v397-release) | [3.2.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v321-release) | [5.11.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5114-release) | [1.4.34](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1434-release) |
 | [3.10.0](#3100-release-2026-06-17) | `v3.10.0` | [3.9.7](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v397-release) | [3.2.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v321-release) | [5.11.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5114-release) | [1.4.34](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1434-release) |
 | [3.9.1](#391-release-2026-05-01) | `v3.9.1` | [3.9.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v394-release) | [3.1.10](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v3110-release) | [5.11.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5111-release) | [1.4.31](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1431-release) |
 | [3.9.0](#390-release-2026-05-01) | `v3.9.0` | [3.9.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v394-release) | [3.1.10](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v3110-release) | [5.11.0](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5110-release) | [1.4.31](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1431-release) |
@@ -53,6 +54,19 @@ Launchpad v3 uses semantic versioning.
 | [3.1.0](#310-release-2025-04-03) | `v3.1.0` | [2.43.2](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v2432-release) | [2.10.2](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v2102-release) | [5.7.7](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v577-release) | [1.4.13](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1413-release) |
 | [3.0.1](#301-release-2025-02-21) | `v3.0.1` | [2.42.0](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v2420-release) | [2.10.0](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v2100-release) | [5.7.5](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v575-release) | [1.4.11](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1411-release) |
 | [3.0.0](#300-release-2025-01-30) | `v3.0.0` | [2.41.0](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v2410-release) | [2.9.3](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v293-release) | [5.7.5](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v575-release) | [1.4.10](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1410-release) |
+
+## 3.11.0 Release (2026-06-30)
+
+> [!IMPORTANT]
+> The Voicebox public API beta is optional and off by default. To try it, run the experimental Voicebox Service (`v1.0.0-beta.1`) and point Launchpad at it with `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT`. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md) for setup. The stable Voicebox Service (`v0.29.0`) continues to serve all other Voicebox traffic.
+
+### New Features
+
+- Added the ability to route Launchpad public API traffic to an experimental build of the Voicebox Service that powers the Voicebox beta. When the beta is enabled and `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT` is set, public API requests are routed to the experimental service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+
+### Security
+
+- Updated internal packages and dependencies to address security vulnerabilities.
 
 ## 3.10.0 Release (2026-06-17)
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -64,6 +64,10 @@ Launchpad v3 uses semantic versioning.
 
 - Added the ability to route existing Launchpad public API traffic to a beta build of the Voicebox Service. This is not a new API - the public API endpoints and response format are unchanged; only the backend service handling the requests is swapped. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
 
+### Bug Fixes
+
+- Fixed an issue where Designer could fail to load with an `Uncaught SyntaxError: Unexpected token '<'` error. Launchpad's bundled web server now serves Designer's pre-compressed (gzipped) assets correctly.
+
 ### Modifications
 
 - Updated bundled Stardog Applications (Designer, Explorer, Studio, Knowledge Catalog) to their latest versions.

--- a/release-notes.md
+++ b/release-notes.md
@@ -58,11 +58,11 @@ Launchpad v3 uses semantic versioning.
 ## 3.11.0 Release (2026-06-30)
 
 > [!IMPORTANT]
-> The Voicebox public API beta is optional and off by default. To try it, run the experimental Voicebox Service (`v1.0.0-beta.1`) and point Launchpad at it with `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT`. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md) for setup. The stable Voicebox Service (`v0.29.0`) continues to serve all other Voicebox traffic.
+> The Voicebox public API beta is optional and off by default. To try it, run the beta Voicebox Service (`v1.0.0-beta.1`) and point Launchpad at it with `VOICEBOX_BETA_SERVICE_ENDPOINT`. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md) for setup. The stable Voicebox Service (`v0.29.0`) continues to serve all other Voicebox traffic.
 
 ### New Features
 
-- Added the ability to route Launchpad public API traffic to an experimental build of the Voicebox Service that powers the Voicebox beta. When the beta is enabled and `VOICEBOX_EXPERIMENTAL_SERVICE_ENDPOINT` is set, public API requests are routed to the experimental service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+- Added the ability to route Launchpad public API traffic to a beta build of the Voicebox Service that powers the Voicebox beta. When the beta is enabled and `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
 
 ### Security
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -62,7 +62,7 @@ Launchpad v3 uses semantic versioning.
 
 ### New Features
 
-- Added the ability to route existing Launchpad public API traffic to a beta build of the Voicebox Service. This is not a new API — the public API endpoints and response format are unchanged; only the backend service handling the requests is swapped. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+- Added the ability to route existing Launchpad public API traffic to a beta build of the Voicebox Service. This is not a new API - the public API endpoints and response format are unchanged; only the backend service handling the requests is swapped. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
 
 ### Modifications
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -34,7 +34,7 @@ Launchpad v3 uses semantic versioning.
 
 | Release | Image Tag | Designer Version | Explorer Version | Studio Version | Knowledge Catalog Version |
 | ----- | ----------- | ------------- | -------------- | -------------- | ------------ |
-| [3.11.0](#3110-release-2026-06-30) | `v3.11.0` | [3.9.7](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v397-release) | [3.2.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v321-release) | [5.11.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5114-release) | [1.4.34](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1434-release) |
+| [3.11.0](#3110-release-2026-06-30) | `v3.11.0` | [3.9.8](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v398-release) | [3.2.2](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v322-release) | [5.11.5](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5115-release) | [1.4.35](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1435-release) |
 | [3.10.0](#3100-release-2026-06-17) | `v3.10.0` | [3.9.7](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v397-release) | [3.2.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v321-release) | [5.11.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5114-release) | [1.4.34](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1434-release) |
 | [3.9.1](#391-release-2026-05-01) | `v3.9.1` | [3.9.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v394-release) | [3.1.10](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v3110-release) | [5.11.1](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5111-release) | [1.4.31](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1431-release) |
 | [3.9.0](#390-release-2026-05-01) | `v3.9.0` | [3.9.4](https://docs.stardog.com/release-notes/stardog-cloud/stardog-designer#v394-release) | [3.1.10](https://docs.stardog.com/release-notes/stardog-cloud/stardog-explorer#v3110-release) | [5.11.0](https://docs.stardog.com/release-notes/stardog-cloud/stardog-studio#v5110-release) | [1.4.31](https://docs.stardog.com/release-notes/stardog-cloud/stardog-knowledge-catalog#v1431-release) |
@@ -63,6 +63,10 @@ Launchpad v3 uses semantic versioning.
 ### New Features
 
 - Added the ability to route Launchpad public API traffic to a beta build of the Voicebox Service that powers the Voicebox beta. When the beta is enabled and `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+
+### Modifications
+
+- Updated bundled Stardog Applications (Designer, Explorer, Studio, Knowledge Catalog) to their latest versions.
 
 ### Security
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -62,7 +62,7 @@ Launchpad v3 uses semantic versioning.
 
 ### New Features
 
-- Added the ability to route Launchpad public API traffic to a beta build of the Voicebox Service that powers the Voicebox beta. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+- Added the ability to route existing Launchpad public API traffic to a beta build of the Voicebox Service. This is not a new API — the public API endpoints and response format are unchanged; only the backend service handling the requests is swapped. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
 
 ### Modifications
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -62,7 +62,7 @@ Launchpad v3 uses semantic versioning.
 
 ### New Features
 
-- Added the ability to route Launchpad public API traffic to a beta build of the Voicebox Service that powers the Voicebox beta. When the beta is enabled and `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
+- Added the ability to route Launchpad public API traffic to a beta build of the Voicebox Service that powers the Voicebox beta. When `VOICEBOX_BETA_SERVICE_ENDPOINT` is set, public API requests are routed to the beta service; all other traffic continues to use the stable service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md).
 
 ### Modifications
 

--- a/voicebox.md
+++ b/voicebox.md
@@ -590,6 +590,13 @@ The Voicebox Service is released independently of Launchpad.
 > [!NOTE] 
 > All available releases of the Voicebox Service are listed below. The image tag for a release is simply the release name prepended with `v` as in `v0.1.1`.
 
+## 1.0.0-beta.1 Release (June 30, 2026)
+
+> [!NOTE]
+> This is a beta build of the next-generation Voicebox Service, distributed under the `v1.0.0-beta.1` tag. It powers the Launchpad public API beta and runs alongside the stable `0.x` service. See [Deploying the Voicebox Service for the Beta](./guides/voicebox-beta-deployment.md) for deployment details.
+
+* First beta of the next-generation Voicebox Service.
+
 ## 0.29.0 Release (May 14, 2026)
 
 * Add support for [Anthropic](#anthropic-configuration) as an LLM provider


### PR DESCRIPTION
## Summary
Documents the Voicebox public API beta for the Launchpad v3.11.0 release. Adds a deployment guide for the experimental Voicebox Service that powers the beta, plus the v3.11.0 and Voicebox `1.0.0-beta.1` release-notes entries.

- resolves https://stardog.atlassian.net/browse/VET-7028 and https://stardog.atlassian.net/browse/VET-6917